### PR TITLE
Refactor function dispatch from a dictionary to a class

### DIFF
--- a/bin/user/mqttpublish.py
+++ b/bin/user/mqttpublish.py
@@ -106,15 +106,18 @@ class PeriodTimespan:
 
     def last7days(self, timestamp):
         ''' Get a timespan for the last 7 days. '''
-        return TimeSpan(time.mktime((datetime.date.fromtimestamp(timestamp) - datetime.timedelta(days=7)).timetuple()), timestamp)
+        return self._last_n_days(7, timestamp)
 
     def last31days(self, timestamp):
         ''' Get a timespan for the last 31 days. '''
-        return TimeSpan(time.mktime((datetime.date.fromtimestamp(timestamp) - datetime.timedelta(days=31)).timetuple()), timestamp)
+        return self._last_n_days(31, timestamp)
 
     def last366days(self, timestamp):
         ''' Get a timespan for the last 366 days. '''
-        return TimeSpan(time.mktime((datetime.date.fromtimestamp(timestamp) - datetime.timedelta(days=366)).timetuple()), timestamp)
+        return self._last_n_days(366, timestamp)
+
+    def _last_n_days(self, days, timestamp):
+        return TimeSpan(time.mktime((datetime.date.fromtimestamp(timestamp) - datetime.timedelta(days=days)).timetuple()), timestamp)
 
 class AbstractPublisher(abc.ABC):
     """ Managing publishing to MQTT. """

--- a/bin/user/mqttpublish.py
+++ b/bin/user/mqttpublish.py
@@ -487,7 +487,7 @@ class MQTTPublish(StdService):
             service_dict = config_dict.get('MQTTPublish', {}).get('PublishWeeWX', {})
 
         # ToDo: Move this after the enable check (need to fix unit tests to allow this)
-        self.period_timespans = PeriodTimespan(6)
+        self.period_timespans = PeriodTimespan(engine.stn_info.week_start)
 
         self.enable = to_bool(service_dict.get('enable', True))
         if not self.enable:

--- a/bin/user/mqttpublish.py
+++ b/bin/user/mqttpublish.py
@@ -28,7 +28,7 @@ from weeutil.weeutil import to_bool, to_float, to_int, TimeSpan
 import weewx
 from weewx.engine import StdService
 
-VERSION = "1.1.0-rc02a"
+VERSION = "1.1.0-rc02b"
 
 # log = logging.getLogger(__name__)
 def setup_logging(logging_level, config_dict):

--- a/bin/user/mqttpublish.py
+++ b/bin/user/mqttpublish.py
@@ -55,7 +55,7 @@ class Logger:
         """ log error messages """
         self.log.error("%s %s", threading.get_native_id(), msg)
 
-class PeriodTimespan:
+class TimeSpanProvider:
     ''' Manage the timespans. '''
     def __init__(self, week_start):
         self.week_start = week_start
@@ -490,7 +490,7 @@ class MQTTPublish(StdService):
             service_dict = config_dict.get('MQTTPublish', {}).get('PublishWeeWX', {})
 
         # ToDo: Move this after the enable check (need to fix unit tests to allow this)
-        self.period_timespans = PeriodTimespan(engine.stn_info.week_start)
+        self.timespan_provider = TimeSpanProvider(engine.stn_info.week_start)
 
         self.enable = to_bool(service_dict.get('enable', True))
         if not self.enable:
@@ -548,7 +548,7 @@ class MQTTPublish(StdService):
                                           self.topics_loop,
                                           self.topics_archive,
                                           self.data_queue,
-                                          self.period_timespans)
+                                          self.timespan_provider)
         self.thread_start()
 
     def configure_fields(self,
@@ -623,7 +623,7 @@ class MQTTPublish(StdService):
             if aggregates:
                 for aggregate in aggregates:
                     if to_bool(aggregates[aggregate].get('enable', True)) \
-                        and aggregates[aggregate]['period'] not in self.period_timespans.period_timespans:
+                        and aggregates[aggregate]['period'] not in self.timespan_provider.period_timespans:
                         raise ValueError(f"Invalid 'period', {aggregates[aggregate]['period']}")
                 weeutil.config.merge_config(aggregates, self.configure_fields(aggregates,
                                                                               ignore,
@@ -708,7 +708,7 @@ class MQTTPublish(StdService):
                                        self.topics_loop,
                                        self.topics_archive,
                                        self.data_queue,
-                                       self.period_timespans)
+                                       self.timespan_provider)
                 self.thread_start()
 
                 self.data_queue.put({'time_stamp': data['dateTime'], 'type': data_type, 'data': data})
@@ -753,7 +753,7 @@ class PublishWeeWXThread(threading.Thread):
         'unix_epoch': None,
     }
 
-    def __init__(self, logger, manager_dict, mqtt_config, topics_loop, topics_archive, data_queue, period_timespans):
+    def __init__(self, logger, manager_dict, mqtt_config, topics_loop, topics_archive, data_queue, timespan_provider):
         threading.Thread.__init__(self)
         self.logger = logger
 
@@ -770,7 +770,7 @@ class PublishWeeWXThread(threading.Thread):
         self.topics_archive = topics_archive
 
         self.data_queue = data_queue
-        self.period_timespans = period_timespans
+        self.timespan_provider = timespan_provider
         self.threading_event = threading.Event()
 
     def update_record(self, topic_dict, record):
@@ -802,7 +802,7 @@ class PublishWeeWXThread(threading.Thread):
             if not to_bool(topic_dict['aggregates'][aggregate_observation].get('enable', True)):
                 continue
 
-            time_span = self.period_timespans.get_timespan(topic_dict['aggregates'][aggregate_observation]['period'],
+            time_span = self.timespan_provider.get_timespan(topic_dict['aggregates'][aggregate_observation]['period'],
                                                            record['dateTime'])
 
             try:

--- a/bin/user/mqttpublish.py
+++ b/bin/user/mqttpublish.py
@@ -55,27 +55,66 @@ class Logger:
         """ log error messages """
         self.log.error("%s %s", threading.get_native_id(), msg)
 
-# ToDo: need to rethink
-period_timespan = {
-    # pylint: disable=unnecessary-lambda
-    'hour': lambda time_stamp: weeutil.weeutil.archiveHoursAgoSpan(time_stamp),
-    'day': lambda time_stamp: weeutil.weeutil.archiveDaySpan(time_stamp),
-    'yesterday': lambda time_stamp: weeutil.weeutil.archiveDaySpan(time_stamp, 1),
-    'week': lambda time_stamp: weeutil.weeutil.archiveWeekSpan(time_stamp),
-    'month': lambda time_stamp: weeutil.weeutil.archiveMonthSpan(time_stamp),
-    'year': lambda time_stamp: weeutil.weeutil.archiveYearSpan(time_stamp),
-    'last24hours': lambda time_stamp: TimeSpan(time_stamp - 86400, time_stamp),
-    'last7days': lambda time_stamp: TimeSpan(time.mktime((datetime.date.fromtimestamp(time_stamp) -
-                                                          datetime.timedelta(days=7)).timetuple()),
-                                             time_stamp),
-    'last31days': lambda time_stamp: TimeSpan(time.mktime((datetime.date.fromtimestamp(time_stamp) -
-                                                           datetime.timedelta(days=31)).timetuple()),
-                                              time_stamp),
-    'last366days': lambda time_stamp: TimeSpan(time.mktime((datetime.date.fromtimestamp(time_stamp) -
-                                                            datetime.timedelta(days=366)).timetuple()),
-                                               time_stamp)
-}
-# pylint: enable=unnecessary-lambda
+class PeriodTimespan:
+    ''' Manage the timespans. '''
+    def __init__(self, week_start):
+        self.week_start = week_start
+        self.period_timespans = {
+            'hour': self.hour,
+            'day': self.day,
+            'yesterday': self.yesterday,
+            'week': self.week,
+            'month': self.month,
+            'year': self.year,
+            'last24hours': self.last24hours,
+            'last7days': self.last7days,
+            'last31days': self.last31days,
+            'last366days': self.last366days,
+        }
+
+    def get_timespan(self, interval, timestamp):
+        ''' Get a timespan for the interval and timstamp. '''
+        return self.period_timespans[interval](timestamp)
+
+    def hour(self, timestamp):
+        ''' Get a timespan for the hour. '''
+        return weeutil.weeutil.archiveHoursAgoSpan(timestamp)
+
+    def day(self, timestamp):
+        ''' Get a timespan for the day. '''
+        return weeutil.weeutil.archiveDaySpan(timestamp)
+
+    def yesterday(self, timestamp):
+        ''' Get a timespan for yesterday. '''
+        return weeutil.weeutil.archiveDaySpan(timestamp, 1)
+
+    def week(self, timestamp):
+        ''' Get a timespan for the running week. '''
+        return weeutil.weeutil.archiveWeekSpan(timestamp, startOfWeek=self.week_start)
+
+    def month(self, timestamp):
+        ''' Get a timespan for the running month. '''
+        return weeutil.weeutil.archiveMonthSpan(timestamp)
+
+    def year(self, timestamp):
+        ''' Get a timespan for the running year. '''
+        return weeutil.weeutil.archiveYearSpan(timestamp)
+
+    def last24hours(self, timestamp):
+        ''' Get a timespan for the last 24 hours. '''
+        return TimeSpan(timestamp - 86400, timestamp)
+
+    def last7days(self, timestamp):
+        ''' Get a timespan for the last 7 days. '''
+        return TimeSpan(time.mktime((datetime.date.fromtimestamp(timestamp) - datetime.timedelta(days=7)).timetuple()), timestamp)
+
+    def last31days(self, timestamp):
+        ''' Get a timespan for the last 31 days. '''
+        return TimeSpan(time.mktime((datetime.date.fromtimestamp(timestamp) - datetime.timedelta(days=31)).timetuple()), timestamp)
+
+    def last366days(self, timestamp):
+        ''' Get a timespan for the last 366 days. '''
+        return TimeSpan(time.mktime((datetime.date.fromtimestamp(timestamp) - datetime.timedelta(days=366)).timetuple()), timestamp)
 
 class AbstractPublisher(abc.ABC):
     """ Managing publishing to MQTT. """
@@ -447,6 +486,9 @@ class MQTTPublish(StdService):
             self.logger.logerr("'PublishWeeWX' is deprecated. Move options to top level, '[MQTTPublish]'.")
             service_dict = config_dict.get('MQTTPublish', {}).get('PublishWeeWX', {})
 
+        # ToDo: Move this after the enable check (need to fix unit tests to allow this)
+        self.period_timespans = PeriodTimespan(6)
+
         self.enable = to_bool(service_dict.get('enable', True))
         if not self.enable:
             self.logger.loginf("Not enabled, exiting.")
@@ -502,7 +544,8 @@ class MQTTPublish(StdService):
                                           self.mqtt_config,
                                           self.topics_loop,
                                           self.topics_archive,
-                                          self.data_queue)
+                                          self.data_queue,
+                                          self.period_timespans)
         self.thread_start()
 
     def configure_fields(self,
@@ -576,7 +619,8 @@ class MQTTPublish(StdService):
             aggregates = topic_dict.get('aggregates', {})
             if aggregates:
                 for aggregate in aggregates:
-                    if to_bool(aggregates[aggregate].get('enable', True)) and aggregates[aggregate]['period'] not in period_timespan:
+                    if to_bool(aggregates[aggregate].get('enable', True)) \
+                        and aggregates[aggregate]['period'] not in self.period_timespans.period_timespans:
                         raise ValueError(f"Invalid 'period', {aggregates[aggregate]['period']}")
                 weeutil.config.merge_config(aggregates, self.configure_fields(aggregates,
                                                                               ignore,
@@ -660,7 +704,8 @@ class MQTTPublish(StdService):
                                        self.mqtt_config,
                                        self.topics_loop,
                                        self.topics_archive,
-                                       self.data_queue)
+                                       self.data_queue,
+                                       self.period_timespans)
                 self.thread_start()
 
                 self.data_queue.put({'time_stamp': data['dateTime'], 'type': data_type, 'data': data})
@@ -705,7 +750,7 @@ class PublishWeeWXThread(threading.Thread):
         'unix_epoch': None,
     }
 
-    def __init__(self, logger, manager_dict, mqtt_config, topics_loop, topics_archive, data_queue):
+    def __init__(self, logger, manager_dict, mqtt_config, topics_loop, topics_archive, data_queue, period_timespans):
         threading.Thread.__init__(self)
         self.logger = logger
 
@@ -722,6 +767,7 @@ class PublishWeeWXThread(threading.Thread):
         self.topics_archive = topics_archive
 
         self.data_queue = data_queue
+        self.period_timespans = period_timespans
         self.threading_event = threading.Event()
 
     def update_record(self, topic_dict, record):
@@ -753,7 +799,8 @@ class PublishWeeWXThread(threading.Thread):
             if not to_bool(topic_dict['aggregates'][aggregate_observation].get('enable', True)):
                 continue
 
-            time_span = period_timespan[topic_dict['aggregates'][aggregate_observation]['period']](record['dateTime'])
+            time_span = self.period_timespans.get_timespan(topic_dict['aggregates'][aggregate_observation]['period'],
+                                                           record['dateTime'])
 
             try:
                 aggregate_value_tuple = \

--- a/bin/user/tests/unit/test_mqttpublish.py
+++ b/bin/user/tests/unit/test_mqttpublish.py
@@ -148,7 +148,8 @@ class TestConfigureTopics(unittest.TestCase):
 
         topic1 = helpers.random_string()
         aggreagate1 = helpers.random_string()
-        timespan_provider = user.mqttpublish.TimeSpanProvider(6)  # ToDo: - random int to instantiate
+        week_start = random.randint(0, 6)
+        timespan_provider = user.mqttpublish.TimeSpanProvider(week_start)
         period = random.choice(list(timespan_provider.period_timespans.keys()))
         service_dict = {
             'topics': {

--- a/bin/user/tests/unit/test_mqttpublish.py
+++ b/bin/user/tests/unit/test_mqttpublish.py
@@ -148,8 +148,8 @@ class TestConfigureTopics(unittest.TestCase):
 
         topic1 = helpers.random_string()
         aggreagate1 = helpers.random_string()
-        period_timespans = user.mqttpublish.PeriodTimespan(6)  # ToDo: - random int to instantiate
-        period = random.choice(list(period_timespans.period_timespans.keys()))
+        timespan_provider = user.mqttpublish.TimeSpanProvider(6)  # ToDo: - random int to instantiate
+        period = random.choice(list(timespan_provider.period_timespans.keys()))
         service_dict = {
             'topics': {
                 topic1: {

--- a/bin/user/tests/unit/test_mqttpublish.py
+++ b/bin/user/tests/unit/test_mqttpublish.py
@@ -148,7 +148,8 @@ class TestConfigureTopics(unittest.TestCase):
 
         topic1 = helpers.random_string()
         aggreagate1 = helpers.random_string()
-        period = random.choice(list(user.mqttpublish.period_timespan.keys()))
+        period_timespans = user.mqttpublish.PeriodTimespan(6)  # ToDo: - random int to instantiate
+        period = random.choice(list(period_timespans.period_timespans.keys()))
         service_dict = {
             'topics': {
                 topic1: {

--- a/bin/user/tests/unit/test_periodtimespan.py
+++ b/bin/user/tests/unit/test_periodtimespan.py
@@ -15,10 +15,25 @@ import random
 import time
 
 import helpers
+
+import weeutil.weeutil
 import user.mqttpublish
 
-class TestLastNDays(unittest.TestCase):
-    def test1(self):
+class TestGetTimeSpan(unittest.TestCase):
+    def test_week(self):
+        with mock.patch('weeutil.weeutil.archiveWeekSpan')as mock_archive_week_span:
+            os.environ['TZ'] = 'America/New_York'
+            time.tzset()
+
+            week_start = random.randint(0, 6)
+            timespan_provider = user.mqttpublish.TimeSpanProvider(week_start)
+
+            now = 1771939800
+            timespan_provider.week(now)
+
+            mock_archive_week_span.assert_called_once_with(now, startOfWeek=week_start)
+
+    def test_last_n_days(self):
         with mock.patch('user.mqttpublish.TimeSpan')as mock_TimeSpan:
             os.environ['TZ'] = 'America/New_York'
             time.tzset()

--- a/bin/user/tests/unit/test_periodtimespan.py
+++ b/bin/user/tests/unit/test_periodtimespan.py
@@ -20,11 +20,11 @@ class TestLastNDays(unittest.TestCase):
         with mock.patch('user.mqttpublish.TimeSpan')as mock_TimeSpan:
 
             week_start = random.randint(0, 6)
-            period_timespans = user.mqttpublish.PeriodTimespan(week_start)
+            timespan_provider = user.mqttpublish.TimeSpanProvider(week_start)
 
             days = 7
             now = 1771939800
-            period_timespans._last_n_days(days, now)
+            timespan_provider._last_n_days(days, now)
 
             day_start_timestamp = 1771304400.0
             mock_TimeSpan.assert_called_once_with(day_start_timestamp, now)

--- a/bin/user/tests/unit/test_periodtimespan.py
+++ b/bin/user/tests/unit/test_periodtimespan.py
@@ -10,7 +10,9 @@
 import unittest
 import mock
 
+import os
 import random
+import time
 
 import helpers
 import user.mqttpublish
@@ -18,6 +20,8 @@ import user.mqttpublish
 class TestLastNDays(unittest.TestCase):
     def test1(self):
         with mock.patch('user.mqttpublish.TimeSpan')as mock_TimeSpan:
+            os.environ['TZ'] = 'America/New_York'
+            time.tzset()
 
             week_start = random.randint(0, 6)
             timespan_provider = user.mqttpublish.TimeSpanProvider(week_start)

--- a/bin/user/tests/unit/test_periodtimespan.py
+++ b/bin/user/tests/unit/test_periodtimespan.py
@@ -16,10 +16,48 @@ import time
 
 import helpers
 
-import weeutil.weeutil
 import user.mqttpublish
 
 class TestGetTimeSpan(unittest.TestCase):
+    def test_hour(self):
+        with mock.patch('weeutil.weeutil.archiveHoursAgoSpan')as mock_archive_hours_ago_span:
+            os.environ['TZ'] = 'America/New_York'
+            time.tzset()
+
+            week_start = random.randint(0, 6)
+            timespan_provider = user.mqttpublish.TimeSpanProvider(week_start)
+
+            now = 1771939800
+            timespan_provider.hour(now)
+
+            mock_archive_hours_ago_span.assert_called_once_with(now)
+
+    def test_day(self):
+        with mock.patch('weeutil.weeutil.archiveDaySpan')as mock_archive_day_span:
+            os.environ['TZ'] = 'America/New_York'
+            time.tzset()
+
+            week_start = random.randint(0, 6)
+            timespan_provider = user.mqttpublish.TimeSpanProvider(week_start)
+
+            now = 1771939800
+            timespan_provider.day(now)
+
+            mock_archive_day_span.assert_called_once_with(now)
+
+    def test_yesterday(self):
+        with mock.patch('weeutil.weeutil.archiveDaySpan')as mock_archive_day_span:
+            os.environ['TZ'] = 'America/New_York'
+            time.tzset()
+
+            week_start = random.randint(0, 6)
+            timespan_provider = user.mqttpublish.TimeSpanProvider(week_start)
+
+            now = 1771939800
+            timespan_provider.yesterday(now)
+
+            mock_archive_day_span.assert_called_once_with(now, 1)
+
     def test_week(self):
         with mock.patch('weeutil.weeutil.archiveWeekSpan')as mock_archive_week_span:
             os.environ['TZ'] = 'America/New_York'
@@ -32,6 +70,46 @@ class TestGetTimeSpan(unittest.TestCase):
             timespan_provider.week(now)
 
             mock_archive_week_span.assert_called_once_with(now, startOfWeek=week_start)
+
+    def test_month(self):
+        with mock.patch('weeutil.weeutil.archiveMonthSpan')as mock_archive_month_span:
+            os.environ['TZ'] = 'America/New_York'
+            time.tzset()
+
+            week_start = random.randint(0, 6)
+            timespan_provider = user.mqttpublish.TimeSpanProvider(week_start)
+
+            now = 1771939800
+            timespan_provider.month(now)
+
+            mock_archive_month_span.assert_called_once_with(now)
+
+    def test_year(self):
+        with mock.patch('weeutil.weeutil.archiveYearSpan')as mock_archive_year_span:
+            os.environ['TZ'] = 'America/New_York'
+            time.tzset()
+
+            week_start = random.randint(0, 6)
+            timespan_provider = user.mqttpublish.TimeSpanProvider(week_start)
+
+            now = 1771939800
+            timespan_provider.year(now)
+
+            mock_archive_year_span.assert_called_once_with(now)
+
+    def test_last24hours(self):
+        with mock.patch('user.mqttpublish.TimeSpan')as mock_TimeSpan:
+            os.environ['TZ'] = 'America/New_York'
+            time.tzset()
+
+            week_start = random.randint(0, 6)
+            timespan_provider = user.mqttpublish.TimeSpanProvider(week_start)
+
+            now = 1771939800
+            timespan_provider.last24hours(now)
+
+            day_start_timestamp = now - 86400
+            mock_TimeSpan.assert_called_once_with(day_start_timestamp, now)
 
     def test_last_n_days(self):
         with mock.patch('user.mqttpublish.TimeSpan')as mock_TimeSpan:

--- a/bin/user/tests/unit/test_periodtimespan.py
+++ b/bin/user/tests/unit/test_periodtimespan.py
@@ -1,0 +1,33 @@
+#    Copyright (c) 2028 Rich Bell <bellrichm@gmail.com>
+#
+#    See the file LICENSE.txt for your full rights.
+#
+
+# pylint: disable=wrong-import-order
+# pylint: disable=missing-module-docstring, missing-class-docstring, missing-function-docstring
+# pylint: disable=invalid-name
+
+import unittest
+import mock
+
+import random
+
+import helpers
+import user.mqttpublish
+
+class TestLastNDays(unittest.TestCase):
+    def test1(self):
+        with mock.patch('user.mqttpublish.TimeSpan')as mock_TimeSpan:
+
+            week_start = random.randint(0, 6)
+            period_timespans = user.mqttpublish.PeriodTimespan(week_start)
+
+            days = 7
+            now = 1771939800
+            period_timespans._last_n_days(days, now)
+
+            day_start_timestamp = 1771304400.0
+            mock_TimeSpan.assert_called_once_with(day_start_timestamp, now)
+
+if __name__ == '__main__':
+    helpers.run_tests()

--- a/bin/user/tests/unit/test_publishthread.py
+++ b/bin/user/tests/unit/test_publishthread.py
@@ -25,11 +25,12 @@ class TestPublishWeeWXThread(unittest.TestCase):
         topics_archive = None
         data_queue = None
 
-        SUT = user.mqttpublish.PublishWeeWXThread(mock_logger, None, config, topics_loop, topics_archive, data_queue)
+        SUT = user.mqttpublish.PublishWeeWXThread(mock_logger, None, config, topics_loop, topics_archive, data_queue, mock.Mock())
 
         field1 = helpers.random_string()
         aggreagate1 = helpers.random_string()
-        period = random.choice(list(user.mqttpublish.period_timespan.keys()))
+        period_timespans = user.mqttpublish.PeriodTimespan(6)  # ToDo: - random int to instantiate
+        period = random.choice(list(period_timespans.period_timespans.keys()))
 
         topic_dict = {
             'unit_system': 1,
@@ -80,7 +81,7 @@ class TestPublishWeeWXThread(unittest.TestCase):
         topics_archive = None
         data_queue_mock = mock.Mock()
 
-        SUT = user.mqttpublish.PublishWeeWXThread(mock_logger, None, config, topics_loop, topics_archive, data_queue_mock)
+        SUT = user.mqttpublish.PublishWeeWXThread(mock_logger, None, config, topics_loop, topics_archive, data_queue_mock, None)
 
         field1 = helpers.random_string()
 

--- a/bin/user/tests/unit/test_publishthread.py
+++ b/bin/user/tests/unit/test_publishthread.py
@@ -29,8 +29,8 @@ class TestPublishWeeWXThread(unittest.TestCase):
 
         field1 = helpers.random_string()
         aggreagate1 = helpers.random_string()
-        period_timespans = user.mqttpublish.PeriodTimespan(6)  # ToDo: - random int to instantiate
-        period = random.choice(list(period_timespans.period_timespans.keys()))
+        timespan_provider = user.mqttpublish.TimeSpanProvider(6)  # ToDo: - random int to instantiate
+        period = random.choice(list(timespan_provider.period_timespans.keys()))
 
         topic_dict = {
             'unit_system': 1,

--- a/bin/user/tests/unit/test_publishthread.py
+++ b/bin/user/tests/unit/test_publishthread.py
@@ -29,7 +29,8 @@ class TestPublishWeeWXThread(unittest.TestCase):
 
         field1 = helpers.random_string()
         aggreagate1 = helpers.random_string()
-        timespan_provider = user.mqttpublish.TimeSpanProvider(6)  # ToDo: - random int to instantiate
+        week_start = random.randint(0, 6)
+        timespan_provider = user.mqttpublish.TimeSpanProvider(week_start)
         period = random.choice(list(timespan_provider.period_timespans.keys()))
 
         topic_dict = {

--- a/changes.txt
+++ b/changes.txt
@@ -7,4 +7,5 @@ Fixes
   When an observation has a unit specified, use that when appending to the observation name.
 
 Enhancements
+- Use the week_start configuration option of the the `[station]` when calculating week aggregates.
 - Improvements when running in 'standalone mode'.

--- a/install.py
+++ b/install.py
@@ -15,7 +15,7 @@ import configobj
 
 from weecfg.extension import ExtensionInstaller
 
-VERSION = "1.1.0-rc02a"
+VERSION = "1.1.0-rc02b"
 
 MQTTPUBLISH_CONFIG = """
 [MQTTPublish]


### PR DESCRIPTION
Using a class instead of dictionary will make it easier to add functionality,
The first add, support the week_start configuration of the station. This will be included in this pull request.